### PR TITLE
Remove Unsplash API key

### DIFF
--- a/app.drey.Damask.json
+++ b/app.drey.Damask.json
@@ -59,8 +59,7 @@
             "builddir": true,
             "buildsystem": "meson",
             "config-opts": [
-                "-Dnasa_api_key=4pL9uuwf0xoBgvT9EJsbZh3xj2ucbfsIhXWXfzTc",
-                "-Dunsplash_access_key=lAVsJ6MPJzNgTih1Qr62-JP5dpO35GhY1o2VD6Rz2PI"
+                "-Dnasa_api_key=4pL9uuwf0xoBgvT9EJsbZh3xj2ucbfsIhXWXfzTc"
             ],
             "sources": [
                 {


### PR DESCRIPTION
The usage of Unsplash in Damask violates the Unsplash API terms. See https://gitlab.gnome.org/subpop/damask/-/issues/38 for details.